### PR TITLE
Reduce execution time for just recipes

### DIFF
--- a/.just/linux.just
+++ b/.just/linux.just
@@ -198,24 +198,62 @@ build:
   #!/usr/bin/env bash
 
   # Set up Bash script to exit on error, enforcing strict mode with `pipefail` option
-  set -euo pipefail
+  set -exuo pipefail
+
+  # Enable advanced globbing
+  shopt -s globstar
 
   # Pull latest ignition-validate image.
   podman pull -q quay.io/coreos/butane:release > /dev/null
 
-  # Find butane files and sort them in reverse order. The `main.bu` file is excluded
-  # in the first search to ensure it is added last for each server.
-  shopt -s globstar
-  readarray -t BUTANE_FILES < <(ls -1 config/**/*.bu | grep -v main.bu | sort -r)
-  BUTANE_FILES+=($(ls -1 config/**/main.bu | sort -r))
+  # Setup jobs
+  JOBS=()
+  MAX_JOBS=8
+  JOBS_STATUS=0
 
-  # Transpile each Butane file and create an Ignition file.
+  # Find & transpile non-primary butane files.
+  readarray -t BUTANE_FILES < <(ls -1 config/**/*.bu | grep -v main.bu | sort -r)
   for FILE in ${BUTANE_FILES[@]}; do
-    if [ "$(basename $FILE)" != "main.bu" ]; then
-      just build-ignition "$FILE"
-    else
-      just build-ignition "$FILE" ".generated"
-    fi
+    # Do not exceed max jobs. Wait for one to complete before proceeding.
+    while (( ${#JOBS[@]} >= MAX_JOBS )); do
+      for INDEX in ${!JOBS[@]}; do
+        if wait "${JOBS[$INDEX]}"; then
+          unset 'JOBS[INDEX]'
+        else
+          JOBS_STATUS=1
+        fi
+      done
+
+      # Compact the array and sleep briefly.
+      JOBS=("${JOBS[@]}")
+      sleep 0.1
+    done
+  
+    just build-ignition "$FILE" &
+    JOBS+=("$!")
+  done
+
+  # Wait for any remaining jobs to complete before proceeding.
+  while (( ${#JOBS[@]} > 0 )); do
+    for INDEX in ${!JOBS[@]}; do
+      if wait "${JOBS[$INDEX]}"; then
+        unset 'JOBS[INDEX]'
+      else
+        JOBS_STATUS=1
+      fi
+    done
+  done
+
+  # Exit if an error occurred while processing non-primary butane files.
+  if [ $JOBS_STATUS -ne 0 ]; then
+    echo "ERROR: An error occurred while building ignition files."
+    exit $JOBS_STATUS
+  fi
+
+  # Find & transpile primary butane files for server configurations.
+  readarray -t BUTANE_FILES < <(ls -1 config/**/main.bu | sort -r)
+  for FILE in ${BUTANE_FILES[@]}; do
+    just build-ignition "$FILE" ".generated"
   done
 
 # Remove all rendered ignition files.

--- a/.just/linux.just
+++ b/.just/linux.just
@@ -394,16 +394,55 @@ lint:
     podman pull -q docker.io/pipelinecomponents/yamllint:latest > /dev/null
   fi
 
+  # Setup jobs
+  JOBS=()
+  MAX_JOBS=8
+  JOBS_STATUS=0
+
   # Find all Butane files and lint them as if they were YAML files.
   shopt -s globstar
-  for FILE in config/**/*.bu; do
+  readarray -t BUTANE_FILES < <(ls -1 config/**/*.bu | sort -r)
+  for FILE in ${BUTANE_FILES[@]}; do
+    # Do not exceed max jobs. Wait for one to complete before proceeding.
+    while (( ${#JOBS[@]} >= MAX_JOBS )); do
+      for INDEX in ${!JOBS[@]}; do
+        if wait "${JOBS[$INDEX]}"; then
+          unset 'JOBS[INDEX]'
+        else
+          JOBS_STATUS=1
+        fi
+      done
+
+      # Compact the array and sleep briefly.
+      JOBS=("${JOBS[@]}")
+      sleep 0.1
+    done
+  
     echo "Linting butane file: $FILE"
     if [ $HAS_YAMLLINT -ne 0 ]; then
       podman run --rm -v .:/code:z,ro docker.io/pipelinecomponents/yamllint:latest yamllint "$FILE"
     else
       yamllint "$FILE"
     fi
+    JOBS+=("$!")
   done
+
+  # Wait for any remaining jobs to complete before proceeding.
+  while (( ${#JOBS[@]} > 0 )); do
+    for INDEX in ${!JOBS[@]}; do
+      if wait "${JOBS[$INDEX]}"; then
+        unset 'JOBS[INDEX]'
+      else
+        JOBS_STATUS=1
+      fi
+    done
+  done
+
+  # Exit if an error occurred while processing butane files.
+  if [ $JOBS_STATUS -ne 0 ]; then
+    echo "ERROR: An error occurred while linting butane files."
+    exit $JOBS_STATUS
+  fi
 
 # Hosts the ignition files for deployment
 [linux]

--- a/.just/linux.just
+++ b/.just/linux.just
@@ -470,11 +470,15 @@ validate:
   # Pull latest ignition-validate image.
   podman pull -q quay.io/coreos/ignition-validate:release > /dev/null
 
-  # Validate all generated Ignition files.
+  # Validate the merged Ignition files.
   if [ -d ".generated/config" ]; then
-    shopt -s globstar
-    for FILE in .generated/**/*.ign; do
-      just validate-ignition "$FILE"
+    for FILE in .generated/config/*.ign; do
+      if [ -s "$FILE" ]; then
+        just validate-ignition "$FILE"
+      else
+        echo "ERROR: The merged ignition file ($FILE) is empty or does not exist."
+        exit 1
+      fi
     done
   else
     echo "ERROR: Unable to locate ignition files directory."

--- a/.just/linux.just
+++ b/.just/linux.just
@@ -198,7 +198,7 @@ build:
   #!/usr/bin/env bash
 
   # Set up Bash script to exit on error, enforcing strict mode with `pipefail` option
-  set -exuo pipefail
+  set -euo pipefail
 
   # Enable advanced globbing
   shopt -s globstar

--- a/.just/linux.just
+++ b/.just/linux.just
@@ -394,55 +394,16 @@ lint:
     podman pull -q docker.io/pipelinecomponents/yamllint:latest > /dev/null
   fi
 
-  # Setup jobs
-  JOBS=()
-  MAX_JOBS=8
-  JOBS_STATUS=0
-
-  # Find all Butane files and lint them as if they were YAML files.
   shopt -s globstar
   readarray -t BUTANE_FILES < <(ls -1 config/**/*.bu | sort -r)
-  for FILE in ${BUTANE_FILES[@]}; do
-    # Do not exceed max jobs. Wait for one to complete before proceeding.
-    while (( ${#JOBS[@]} >= MAX_JOBS )); do
-      for INDEX in ${!JOBS[@]}; do
-        if wait "${JOBS[$INDEX]}"; then
-          unset 'JOBS[INDEX]'
-        else
-          JOBS_STATUS=1
-        fi
-      done
 
-      # Compact the array and sleep briefly.
-      JOBS=("${JOBS[@]}")
-      sleep 0.1
-    done
-  
-    echo "Linting butane file: $FILE"
-    if [ $HAS_YAMLLINT -ne 0 ]; then
-      podman run --rm -v .:/code:z,ro docker.io/pipelinecomponents/yamllint:latest yamllint "$FILE"
-    else
-      yamllint "$FILE"
-    fi
-    JOBS+=("$!")
-  done
-
-  # Wait for any remaining jobs to complete before proceeding.
-  while (( ${#JOBS[@]} > 0 )); do
-    for INDEX in ${!JOBS[@]}; do
-      if wait "${JOBS[$INDEX]}"; then
-        unset 'JOBS[INDEX]'
-      else
-        JOBS_STATUS=1
-      fi
-    done
-  done
-
-  # Exit if an error occurred while processing butane files.
-  if [ $JOBS_STATUS -ne 0 ]; then
-    echo "ERROR: An error occurred while linting butane files."
-    exit $JOBS_STATUS
+  if [ $HAS_YAMLLINT -ne 0 ]; then
+    podman run --rm -v .:/code:z,ro docker.io/pipelinecomponents/yamllint:latest yamllint "${BUTANE_FILES[@]}"
+  else
+    yamllint "${BUTANE_FILES[@]}"
   fi
+
+  echo "All butane files passed linting checks."
 
 # Hosts the ignition files for deployment
 [linux]


### PR DESCRIPTION
Reduces execution time for the following recipes:
  - build: Implements parallel processing scheme using a max of 8 jobs.
  - lint: Passes the entire array of butane files to yamllint for bulk processing rather than using a loop and potentially multiple containers.
  - validate: Removes validation of ignition files to the primary ignition files that have all the merged content.

With these changes, execution time for just run is reduced to about 30s.